### PR TITLE
fix: Remove incorrect package.json line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "fe_evaluation_2025",
       "version": "0.1.0",
       "dependencies": {
-        "'": "file:toolpad/core/useNotifications'",
         "@apollo/client": "^3.13.8",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -41,10 +40,6 @@
         "prettier": "^3.5.3",
         "typescript-eslint": "^8.32.0"
       }
-    },
-    "node_modules/'": {
-      "resolved": "toolpad/core/useNotifications'",
-      "link": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
@@ -19855,6 +19850,8 @@
         "zen-observable": "0.8.15"
       }
     },
-    "toolpad/core/useNotifications'": {}
+    "toolpad/core/useNotifications'": {
+      "extraneous": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "'": "file:toolpad/core/useNotifications'",
     "@apollo/client": "^3.13.8",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",


### PR DESCRIPTION
Addressing issue [Incorrect devDependency in package.json](https://github.com/andyg901/fe_evaluation_2025/issues/1)

Line was added by npm when installing @toolpad for MaterialUI. The was no need for linking `useNotifications`.