### PR TITLE
Refactor for readability / Move error displaying logic

### DIFF
--- a/cypress/e2e/RepositoriesList.cy.ts
+++ b/cypress/e2e/RepositoriesList.cy.ts
@@ -4,9 +4,7 @@ describe("Repository list", () => {
 
     cy.get('[data-testid="repositories-list:table"]').should("exist");
 
-    cy.get('[data-testid="repositories-list:table:loader"]').should(
-      "not.exist",
-    );
+    cy.get('[data-testid="table:loader"]').should("not.exist");
 
     cy.get('[data-testid="repositories-list:table:row"]').should(
       "have.length",

--- a/src/repositories/components/RepositoriesTable.tsx
+++ b/src/repositories/components/RepositoriesTable.tsx
@@ -1,8 +1,5 @@
 import {
-  Box,
-  CircularProgress,
   Paper,
-  SxProps,
   Table,
   TableBody,
   TableCell,
@@ -10,22 +7,15 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
-import {
-  LinkOutlined,
-  RestaurantOutlined,
-  StarOutline,
-} from "@mui/icons-material";
 import { useRepositoriesFetch } from "../hooks/useRepositoriesFetch";
 import { RepositoriesTablePagination } from "./RepositoriesTablePagination";
-
-const cellAlignment: SxProps = {
-  display: "flex",
-  alignItems: "center",
-  gap: "5px",
-};
+import { TableRowLoader } from "../../shared/components/TableRowLoader";
+import { useNotifications } from "@toolpad/core";
+import { RepositoriesTableRow } from "./RepositoriesTableRow";
 
 export const RepositoriesTable = () => {
   const {
+    error,
     loading,
     results: {
       data,
@@ -33,6 +23,15 @@ export const RepositoriesTable = () => {
     },
     changePage,
   } = useRepositoriesFetch();
+  const notifications = useNotifications();
+
+  // Inform about data fetching issue
+  if (!loading && error) {
+    notifications.show("There was an error while fetching data", {
+      severity: "error",
+      autoHideDuration: 3000,
+    });
+  }
 
   return (
     <>
@@ -51,44 +50,11 @@ export const RepositoriesTable = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading && (
-              <TableRow data-testid="repositories-list:table:loader">
-                <TableCell colSpan={3} align="center">
-                  <CircularProgress role="load-indicator" />
-                </TableCell>
-              </TableRow>
+            {loading ? (
+              <TableRowLoader colspan={3} />
+            ) : (
+              data.map((dItem) => <RepositoriesTableRow data={dItem} />)
             )}
-            {!loading &&
-              data.map((row) => (
-                <TableRow
-                  key={row.nameWithOwner}
-                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-                  data-testid="repositories-list:table:row"
-                >
-                  <TableCell
-                    scope="row"
-                    data-testid="repositories-list:table:cell-name"
-                  >
-                    <a href={row.url} target="_blank" rel="noreferrer">
-                      <Box sx={cellAlignment}>
-                        <LinkOutlined /> {row.nameWithOwner}
-                      </Box>
-                    </a>
-                  </TableCell>
-                  <TableCell data-testid="repositories-list:table:cell-stargazer-count">
-                    <Box sx={cellAlignment}>
-                      <StarOutline />
-                      {row.stargazerCount}
-                    </Box>
-                  </TableCell>
-                  <TableCell data-testid="repositories-list:table:cell-fork-count">
-                    <Box sx={cellAlignment}>
-                      <RestaurantOutlined />
-                      {row.forkCount}
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/repositories/components/RepositoriesTableRow.tsx
+++ b/src/repositories/components/RepositoriesTableRow.tsx
@@ -1,0 +1,47 @@
+import { Box, SxProps, TableCell, TableRow } from "@mui/material";
+import { Repository } from "../../shared/types/repository";
+import {
+  LinkOutlined,
+  RestaurantOutlined,
+  StarOutline,
+} from "@mui/icons-material";
+
+interface RepositoriesTableRoProps {
+  data: Repository;
+}
+
+const cellAlignment: SxProps = {
+  display: "flex",
+  alignItems: "center",
+  gap: "5px",
+};
+
+export const RepositoriesTableRow = ({ data }: RepositoriesTableRoProps) => {
+  return (
+    <TableRow
+      key={data.nameWithOwner}
+      sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+      data-testid="repositories-list:table:row"
+    >
+      <TableCell scope="row" data-testid="repositories-list:table:cell-name">
+        <a href={data.url} target="_blank" rel="noreferrer">
+          <Box sx={cellAlignment}>
+            <LinkOutlined /> {data.nameWithOwner}
+          </Box>
+        </a>
+      </TableCell>
+      <TableCell data-testid="repositories-list:table:cell-stargazer-count">
+        <Box sx={cellAlignment}>
+          <StarOutline />
+          {data.stargazerCount}
+        </Box>
+      </TableCell>
+      <TableCell data-testid="repositories-list:table:cell-fork-count">
+        <Box sx={cellAlignment}>
+          <RestaurantOutlined />
+          {data.forkCount}
+        </Box>
+      </TableCell>
+    </TableRow>
+  );
+};

--- a/src/repositories/hooks/useRepositoriesFetch.ts
+++ b/src/repositories/hooks/useRepositoriesFetch.ts
@@ -2,7 +2,6 @@ import { useContext, useEffect, useState } from "react";
 import { AppContext } from "../../app/AppContext";
 import { useLazyQuery } from "@apollo/client";
 import { SEARCH_REPOSITORIES } from "../queries/searchRepositories";
-import { useNotifications } from "@toolpad/core";
 import { Repository } from "../../shared/types/repository";
 import { mapQueryResponse } from "../utils/dataMapper";
 import { Pagination } from "../../shared/types/graphql";
@@ -40,7 +39,6 @@ export const useRepositoriesFetch = () => {
       startCursor: "",
     },
   });
-  const notifications = useNotifications();
   const { searchQuery } = useContext(AppContext);
   const [getRepositories, { loading, error, data }] =
     useLazyQuery(SEARCH_REPOSITORIES);
@@ -75,21 +73,13 @@ export const useRepositoriesFetch = () => {
   }, [queryParameters, getRepositories]);
 
   useEffect(() => {
-    // Inform about data fetching issue
-    if (!loading && error) {
-      notifications.show("There was an error while fetching data", {
-        severity: "error",
-        autoHideDuration: 3000,
-      });
-    }
-
     if (!loading && !error && data) {
       setResults({
         data: mapQueryResponse(data),
         pagination: data.search.pageInfo,
       });
     }
-  }, [loading, error, data, notifications]);
+  }, [loading, error, data]);
 
   const changePage = (page: "prev" | "next") => {
     if (page === "prev") {
@@ -114,6 +104,7 @@ export const useRepositoriesFetch = () => {
   };
 
   return {
+    error,
     loading,
     results,
     changePage,

--- a/src/repositories/pages/RepositoriesPage.spec.tsx
+++ b/src/repositories/pages/RepositoriesPage.spec.tsx
@@ -26,7 +26,7 @@ it("renders without error", async () => {
 it("represent loading state correctly", async () => {
   render(Page(mocks));
 
-  const loader = await screen.findByTestId("repositories-list:table:loader");
+  const loader = await screen.findByTestId("table:loader");
 
   expect(loader).toBeInTheDocument();
   expect(

--- a/src/shared/components/TableRowLoader.tsx
+++ b/src/shared/components/TableRowLoader.tsx
@@ -1,0 +1,15 @@
+import { CircularProgress, TableCell, TableRow } from "@mui/material";
+
+interface TableRowLoaderProps {
+  colspan: number;
+}
+
+export const TableRowLoader = ({ colspan }: TableRowLoaderProps) => {
+  return (
+    <TableRow data-testid="table:loader">
+      <TableCell colSpan={colspan} align="center">
+        <CircularProgress role="load-indicator" />
+      </TableCell>
+    </TableRow>
+  );
+};


### PR DESCRIPTION
## PR addresses issues:
1. [[data.map after &&](https://github.com/andyg901/fe_evaluation_2025/issues/4)](https://github.com/andyg901/fe_evaluation_2025/issues/4)
2. [[Perfect place for ternary](https://github.com/andyg901/fe_evaluation_2025/issues/3)](https://github.com/andyg901/fe_evaluation_2025/issues/3)
3. [[useRepositoriesFetch hook logic](https://github.com/andyg901/fe_evaluation_2025/issues/2)](https://github.com/andyg901/fe_evaluation_2025/issues/2)

### Ad. 1, Ad. 2
Moved table row with loader indicator into separate component. Moved repositories table row also into separate component. Then composed loading/data display state within ternary operator.

### Ad. 3
Error handling moved into component utilizing `useRepositoriesFetch` hook.